### PR TITLE
Add one-time setups script

### DIFF
--- a/src/rpi/setup_onetime.sh
+++ b/src/rpi/setup_onetime.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+sudo -s
+echo "enable_uart=1" >> /boot/config.txt
+
+systemctl stop serial-getty@ttyS0.service
+systemctl disable serial-getty@ttyS0.service
+
+echo "Remove console=serial0,115200"
+nano /boot/cmdline.txt
+
+echo "Reboot the device and try again!"


### PR DESCRIPTION
Signed-off-by: Misha Turnbull <mishaturnbull@gmail.com>

This is new feature pull request.

Summary:
Adds a one-time use setup script that can be run on a fresh install of Raspbian on a RPi model 3 or newer to configure the device for a UART serial connection to another device.

More reference information can be found here:
https://community.particle.io/t/tutorial-enable-gpio-serial-on-rpi-3/30194



